### PR TITLE
Fix problem in assert message

### DIFF
--- a/language-translation/problem_unittests.py
+++ b/language-translation/problem_unittests.py
@@ -349,7 +349,7 @@ def test_decoding_layer_train(decoding_layer_train):
                 'Found wrong type: {}'.format(type(train_decoder_output))
 
             assert train_decoder_output.rnn_output.get_shape().as_list() == [batch_size, None, vocab_size], \
-                'Wrong shape returned.  Found {}'.format(train_decoder_output.get_shape())
+                'Wrong shape returned.  Found {}'.format(train_decoder_output.rnn_output.get_shape())
 
     _print_success_message()
 


### PR DESCRIPTION
The assert message wrongly evaluated ```train_decoder_output.get_shape()```, missing ```.rnn_output``` and causing an error instead of printing the assert failure message.